### PR TITLE
Syr bug fix linear gradient wrong keys

### DIFF
--- a/ios/SyrNative/SyrNative/SyrLinearGradient.m
+++ b/ios/SyrNative/SyrNative/SyrLinearGradient.m
@@ -31,7 +31,7 @@ SYR_EXPORT_MODULE(LinearGradient)
     gradientLayer.frame = view.layer.bounds;
     
     NSMutableArray* colors = [[NSMutableArray alloc] init];
-    NSArray* gradientColors = [[component objectForKey:@"props"] objectForKey:@"colors"];
+    NSArray* gradientColors = [[[component objectForKey:@"instance"] objectForKey:@"props"] objectForKey:@"colors"];
     NSString* direction = [[component valueForKey:@"attributes"]objectForKey:@"direction"];
     
     if ([direction  isEqual: rightToleft]) {
@@ -74,10 +74,10 @@ SYR_EXPORT_MODULE(LinearGradient)
     
     gradientLayer.colors = colors;
     
-    gradientLayer.locations = [NSArray arrayWithObjects:
-                               [NSNumber numberWithFloat:0.0f],
-                               [NSNumber numberWithFloat:1.0f],
-                               nil];
+//    gradientLayer.locations = [NSArray arrayWithObjects:
+//                               [NSNumber numberWithFloat:0.0f],
+//                               [NSNumber numberWithFloat:1.0f],
+//                               nil];
     
     [view.layer addSublayer:gradientLayer];
     

--- a/ios/SyrNative/SyrNative/SyrLinearGradient.m
+++ b/ios/SyrNative/SyrNative/SyrLinearGradient.m
@@ -74,10 +74,10 @@ SYR_EXPORT_MODULE(LinearGradient)
     
     gradientLayer.colors = colors;
     
-//    gradientLayer.locations = [NSArray arrayWithObjects:
-//                               [NSNumber numberWithFloat:0.0f],
-//                               [NSNumber numberWithFloat:1.0f],
-//                               nil];
+    gradientLayer.locations = [NSArray arrayWithObjects:
+                               [NSNumber numberWithFloat:0.0f],
+                               [NSNumber numberWithFloat:1.0f],
+                               nil];
     
     [view.layer addSublayer:gradientLayer];
     


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request (thanks kent!)

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Small changes to the key value pairs in the Linear Gradient

<!-- Why are these changes necessary? -->
**Why**: The access of keys is essentially in the wrong order, which cuases the colors property to be nil

<!-- How were these changes implemented? -->
**How**: made it so that it gets, the instance , then the props, then the colors

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation
- [ x] Tests
- [ x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
